### PR TITLE
feat: Complete Material 3 theme migration and UI/UX improvements

### DIFF
--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Shapes.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Shapes.kt
@@ -1,0 +1,15 @@
+package dev.chungjungsoo.gptmobile.presentation.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+// Material 3 Shape scale
+val AppShapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(28.dp)
+)
+

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Theme.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -393,6 +395,15 @@ val unspecified_scheme = ColorFamily(
     Color.Unspecified
 )
 
+// CompositionLocal for extended colors
+val LocalExtendedColors = staticCompositionLocalOf {
+    ExtendedColorScheme(
+        customColor1 = unspecified_scheme,
+        chatGPTOfficialColor = unspecified_scheme,
+        customColor2 = unspecified_scheme
+    )
+}
+
 @Composable
 fun GPTMobileTheme(
     dynamicTheme: DynamicTheme = DynamicTheme.OFF,
@@ -415,6 +426,13 @@ fun GPTMobileTheme(
         useDarkTheme -> darkScheme
         else -> lightScheme
     }
+    
+    // Select extended colors based on theme
+    val extendedColors = when {
+        useDarkTheme -> extendedDark
+        else -> extendedLight
+    }
+    
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
@@ -424,9 +442,12 @@ fun GPTMobileTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = AppTypography,
-        content = content
-    )
+    CompositionLocalProvider(LocalExtendedColors provides extendedColors) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = AppTypography,
+            shapes = AppShapes,
+            content = content
+        )
+    }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/theme/Type.kt
@@ -1,5 +1,116 @@
 package dev.chungjungsoo.gptmobile.presentation.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
-val AppTypography = Typography()
+// Material 3 Typography scale
+val AppTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -17,7 +17,7 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -43,18 +43,14 @@ fun UserChatBubble(
     onEditClick: () -> Unit,
     onCopyClick: () -> Unit
 ) {
-    val cardColor = CardColors(
-        containerColor = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledContentColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.38f),
-        disabledContainerColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.38f)
-    )
-
     Column(horizontalAlignment = Alignment.End) {
         Card(
             modifier = modifier,
             shape = RoundedCornerShape(32.dp),
-            colors = cardColor
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            )
         ) {
             MarkdownText(
                 modifier = Modifier.padding(16.dp),
@@ -84,18 +80,14 @@ fun OpponentChatBubble(
     onCopyClick: () -> Unit = {},
     onRetryClick: () -> Unit = {}
 ) {
-    val cardColor = CardColors(
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        disabledContentColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.38f),
-        disabledContainerColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.38f)
-    )
-
     Column(modifier = modifier) {
         Column(horizontalAlignment = Alignment.End) {
             Card(
                 shape = RoundedCornerShape(32.dp),
-                colors = cardColor
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
             ) {
                 MarkdownText(
                     modifier = Modifier.padding(24.dp),

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
@@ -213,18 +213,21 @@ fun HomeTopAppBar(
     navigationOnClick: () -> Unit
 ) {
     TopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            scrolledContainerColor = if (isSelectionMode) MaterialTheme.colorScheme.primaryContainer else Color.Unspecified,
-            containerColor = if (isSelectionMode) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.background,
-            titleContentColor = if (isSelectionMode) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onBackground
-        ),
+        colors = if (isSelectionMode) {
+            TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                scrolledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        } else {
+            TopAppBarDefaults.topAppBarColors()
+        },
         title = {
             if (isSelectionMode) {
                 Text(
                     modifier = Modifier.padding(4.dp),
                     text = stringResource(R.string.chats_selected, selectedChats),
                     maxLines = 1,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
                     overflow = TextOverflow.Ellipsis
                 )
             } else {
@@ -245,7 +248,6 @@ fun HomeTopAppBar(
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.Close,
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
                         contentDescription = stringResource(R.string.close)
                     )
                 }
@@ -259,7 +261,6 @@ fun HomeTopAppBar(
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Delete,
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
                         contentDescription = stringResource(R.string.delete)
                     )
                 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/AboutScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/AboutScreen.kt
@@ -170,10 +170,6 @@ fun AboutTopAppBar(
     navigationOnClick: () -> Unit
 ) {
     LargeTopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            titleContentColor = MaterialTheme.colorScheme.onBackground
-        ),
         title = {
             Text(
                 modifier = Modifier.padding(4.dp),

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/LicenseScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/LicenseScreen.kt
@@ -52,10 +52,6 @@ private fun LicenseTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior
 ) {
     LargeTopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            titleContentColor = MaterialTheme.colorScheme.onBackground
-        ),
         title = {
             Text(
                 modifier = Modifier.padding(4.dp),

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -102,7 +102,7 @@ fun PlatformSettingScreen(
                 modifier = Modifier.height(64.dp),
                 title = stringResource(R.string.api_url),
                 description = url,
-                enabled = enabled && platform.name != ApiType.GOOGLE,
+                enabled = enabled && platform?.name != ApiType.GOOGLE,
                 onItemClick = settingViewModel::openApiUrlDialog,
                 showTrailingIcon = false,
                 showLeadingIcon = true,
@@ -207,10 +207,6 @@ fun PlatformTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior
 ) {
     LargeTopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            titleContentColor = MaterialTheme.colorScheme.onBackground
-        ),
         title = {
             Text(
                 modifier = Modifier.padding(4.dp),

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/SettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/SettingScreen.kt
@@ -100,10 +100,6 @@ private fun SettingTopBar(
     navigationOnClick: () -> Unit
 ) {
     LargeTopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            titleContentColor = MaterialTheme.colorScheme.onBackground
-        ),
         title = {
             Text(
                 modifier = Modifier.padding(4.dp),


### PR DESCRIPTION
- Added proper Material 3 Typography scale with all text styles (display, headline, title, body, label)
- Added Material 3 Shapes scale (extraSmall to extraLarge)
- Integrated ExtendedColorScheme with CompositionLocal for custom theme colors
- Fixed ChatBubble cards to use CardDefaults instead of manual CardColors construction
- Removed hardcoded colors from TopAppBar in all setting screens
- Improved HomeScreen TopAppBar to use proper Material 3 defaults while maintaining selection mode styling
- Fixed nullable platform bug in PlatformSettingScreen
- Audited dark mode implementation - all colors properly use MaterialTheme.colorScheme

All changes maintain backward compatibility and improve theme consistency across light and dark modes.